### PR TITLE
Make upgrade to Laravel 5.7 backward compatible

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,12 +29,12 @@
     "require": {
         "php": ">=7.0.0",
         "brackets/admin-ui": "dev-upgrade-57 as 2.0.x-dev",
-        "illuminate/support": "5.7.*"
+        "illuminate/support": "5.5.*|5.6.*|5.7.*"
     },
     "require-dev": {
-        "orchestra/testbench": "~3.7",
+        "orchestra/testbench": "~3.5|~3.6|~3.7",
         "mockery/mockery": "^1.0",
-        "phpunit/phpunit": "~7.0"
+        "phpunit/phpunit": "~6.3|~7.0"
     },
     "autoload": {
         "classmap": [],

--- a/src/Http/Controllers/Auth/ForgotPasswordController.php
+++ b/src/Http/Controllers/Auth/ForgotPasswordController.php
@@ -59,7 +59,9 @@ class ForgotPasswordController extends Controller
             $request->only('email')
         );
 
-        return $this->sendResetLinkResponse($request, Password::RESET_LINK_SENT);
+        return $response == Password::RESET_LINK_SENT
+            ? $this->sendResetLinkResponse($request, $response)
+            : $this->sendResetLinkFailedResponse($request, $response);
     }
 
     /**
@@ -76,5 +78,23 @@ class ForgotPasswordController extends Controller
             $message = trans('brackets/admin-auth::admin.passwords.sent');
         }
         return back()->with('status', $message);
+    }
+
+    /**
+     * Get the response for a failed password reset link.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  string  $response
+     * @return \Illuminate\Http\RedirectResponse|\Illuminate\Http\JsonResponse
+     */
+    protected function sendResetLinkFailedResponse(Request $request, $response)
+    {
+        $message = trans($response);
+
+        // TODO what should be here?
+        
+        return back()
+            ->withInput($request->only('email'))
+            ->withErrors(['email' => $message]);
     }
 }

--- a/src/Http/Controllers/Auth/ResetPasswordController.php
+++ b/src/Http/Controllers/Auth/ResetPasswordController.php
@@ -78,6 +78,34 @@ class ResetPasswordController extends Controller
     }
 
     /**
+     * Reset the given user's password.
+     *
+     * @param  \Illuminate\Http\Request $request
+     * @return \Illuminate\Http\RedirectResponse|\Illuminate\Http\JsonResponse
+     * @throws \Illuminate\Validation\ValidationException
+     */
+    public function reset(Request $request)
+    {
+        $this->validate($request, $this->rules(), $this->validationErrorMessages());
+
+        // Here we will attempt to reset the user's password. If it is successful we
+        // will update the password on an actual user model and persist it to the
+        // database. Otherwise we will parse the error and return the response.
+        $response = $this->broker()->reset(
+            $this->credentials($request), function ($user, $password) {
+            $this->resetPassword($user, $password);
+        }
+        );
+
+        // If the password was successfully reset, we will redirect the user back to
+        // the application's home authenticated view. If there is an error we can
+        // redirect them back to where they came from with their error message.
+        return $response == Password::PASSWORD_RESET
+            ? $this->sendResetResponse($request, $response)
+            : $this->sendResetFailedResponse($request, $response);
+    }
+
+    /**
      * Get the response for a successful password reset.
      *
      * @param Request $request


### PR DESCRIPTION
@dejwCake what do you say if we override also all the method that make calls to the method which signature was changed? This way it could be backward compatible (with all laravel version - 5.5, 5.6 and 5.7) What do you think?

In new big upcoming update of admin-auth we would address this issue differently. Huh?