### PR TITLE
Add translations for dropdown labels

### DIFF
--- a/resources/lang/en/admin.php
+++ b/resources/lang/en/admin.php
@@ -48,6 +48,8 @@ return [
     ],
 
     'profile_dropdown' => [
+        'profile' => 'Profile',
+        'password' => 'Password',
         'logout' => 'Logout',
     ],
 ];


### PR DESCRIPTION
This PR is the follow-up of the [admin generator PR](https://github.com/BRACKETS-by-TRIAD/admin-generator/pull/61). 
It allows users to translate the two first items of the dropdown admin menu.